### PR TITLE
fix: dialog and select behaviour with overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules
 dist
 storybook-static
 build-storybook.log
-./static
+static/
 coverage

--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -15,11 +15,11 @@
  */
 
 .dialog {
-    @apply mx-auto w-full rounded bg-background text-background-contrast px-6 py-4 max-w-xl
+    @apply mx-auto w-full rounded bg-background text-background-contrast overflow-y-auto max-w-xl max-h-[80vh]
 }
 
 .dialog__container {
-    @apply relative z-50
+    @apply relative z-50 px-6 py-4
 }
 
 .dialog__overlay {
@@ -31,7 +31,11 @@
 }
 
 .dialog__head {
-    @apply mb-6 flex gap-4
+    @apply bg-background flex gap-4 sticky top-0 z-10 px-6 pt-4
+}
+
+.dialog__body {
+    @apply px-6 py-4
 }
 
 .dialog__title {

--- a/src/components/Select/Select.css
+++ b/src/components/Select/Select.css
@@ -21,7 +21,8 @@
 }
 
 .select__options {
-    @apply absolute z-20 mt-2 w-full rounded-theme-sm bg-background text-background-contrast py-2 border border-neutral
+    @apply fixed z-20 mt-2 w-full max-w-[420px] max-h-[300px] overflow-y-auto rounded-theme-sm bg-background
+    text-background-contrast py-2 border border-neutral focus-visible:outline-none
 }
 
 .select__option {
@@ -33,7 +34,7 @@
 }
 
 .select__endAdornment {
-    @apply absolute inset-y-0 right-0 flex items-center pr-4
+    @apply absolute inset-y-0 right-0 flex items-center pr-4 focus-visible:outline-none
 }
 
 .select__endAdornment__icon {
@@ -41,7 +42,7 @@
 }
 
 .select__startAdornment {
-    @apply absolute inset-y-0 left-0 flex items-center pl-4
+    @apply absolute inset-y-0 left-0 flex items-center pl-4 focus-visible:outline-none
 }
 
 .select__startAdornment__icon {


### PR DESCRIPTION
## Description

Dialog and select behaviour with overflow. Removed outline focus visible on select. Now the dialog show the select options outside the dialog and not cut it.

<img width="592" alt="Screenshot 2023-06-09 alle 12 11 19" src="https://github.com/arkemishub/ui/assets/81776297/5a6dd97d-f22e-4530-8d8e-8ec327633ec2">


## Test

- [x] I have added tests that prove my fix is effective or that my feature works