### PR TITLE
fix: use ReactNode instead of string for renderLabel

### DIFF
--- a/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/Autocomplete.test.tsx
@@ -30,7 +30,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.id}
+        getDisplayValue={(val) => val.id}
       />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -41,7 +41,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.id}
+        getDisplayValue={(val) => val.id}
       />
     );
     expect(getByTestId("arke-autocomplete")).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.id}
+        getDisplayValue={(val) => val.id}
         onInputChange={onInputChange}
       />
     );
@@ -69,7 +69,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        getDisplayValue={(val) => val.name}
       />
     );
     act(() => {
@@ -85,7 +85,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={onChange}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        getDisplayValue={(val) => val.name}
       />
     );
     act(() => {
@@ -104,13 +104,14 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        getDisplayValue={(val) => val.name}
+        renderLabel={(val) => val.id}
       />
     );
     act(() => {
       userEvent.type(getByTestId("arke-autocomplete"), "Test");
     });
-    expect(getByText("Test 1")).toBeInTheDocument();
+    expect(getByText("1")).toBeInTheDocument();
   });
 
   test("should render value when is selected", () => {
@@ -118,7 +119,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        getDisplayValue={(val) => val.name}
         value={mockValues[0]}
       />
     );
@@ -130,7 +131,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        getDisplayValue={(val) => val.name}
         multiple
         value={mockValues}
       />
@@ -145,7 +146,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={onChange}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        getDisplayValue={(val) => val.name}
         multiple
         value={[mockValues[0], mockValues[1]]}
       />

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -51,23 +51,24 @@ function Autocomplete<TValue>({
   helperText,
   onChange,
   onInputChange,
+  getDisplayValue,
   renderChips = true,
 }: IAutocompleteProps<TValue, boolean | undefined>): JSX.Element {
   const [inputValue, setInputValue] = useState<string>("");
   type TActualValue = true extends typeof multiple ? TValue[] : TValue;
 
-  const onRenderLabel = (value: TValue) =>
+  const onGetDisplayValue = (value: TValue) =>
     (value &&
       (Array.isArray(value)
-        ? (value as TValue[]).map((val) => renderLabel(val)).join(", ")
-        : renderLabel(value))) ??
+        ? (value as TValue[]).map((val) => getDisplayValue(val)).join(", ")
+        : getDisplayValue(value))) ??
     "";
 
   useEffect(() => {
     if (multiple) {
       setInputValue("");
     } else {
-      setInputValue(onRenderLabel(value as TValue));
+      setInputValue(onGetDisplayValue(value as TValue));
     }
   }, [value]);
 
@@ -98,7 +99,7 @@ function Autocomplete<TValue>({
             <Combobox.Input
               as={Fragment}
               onChange={(e) => onInputChange?.(e)}
-              displayValue={onRenderLabel}
+              displayValue={onGetDisplayValue}
             >
               <>
                 <div
@@ -118,7 +119,7 @@ function Autocomplete<TValue>({
                         className="autocomplete__chip"
                         onDelete={() => handleOnDelete(index)}
                       >
-                        {onRenderLabel(item)}
+                        {onGetDisplayValue(item)}
                       </Chip>
                     ))}
                   <input
@@ -169,7 +170,7 @@ function Autocomplete<TValue>({
                       (selected || active) && "autocomplete__option--active"
                     )}
                   >
-                    {renderLabel?.(val)}
+                    {renderLabel ? renderLabel(val) : getDisplayValue(val)}
                   </li>
                 )}
               </Combobox.Option>

--- a/src/components/Autocomplete/Autocomplete.types.ts
+++ b/src/components/Autocomplete/Autocomplete.types.ts
@@ -19,7 +19,7 @@ import { ChangeEventHandler, ReactNode } from "react";
 type AutocompleteBaseProps<TValue> = {
   values?: TValue[];
   label?: string;
-  renderLabel: (val: TValue) => string;
+  renderLabel: (val: TValue) => ReactNode;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
   placeholder?: string;

--- a/src/components/Autocomplete/Autocomplete.types.ts
+++ b/src/components/Autocomplete/Autocomplete.types.ts
@@ -19,7 +19,7 @@ import { ChangeEventHandler, ReactNode } from "react";
 type AutocompleteBaseProps<TValue> = {
   values?: TValue[];
   label?: string;
-  renderLabel: (val: TValue) => ReactNode;
+  renderLabel?: (val: TValue) => ReactNode;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
   placeholder?: string;
@@ -28,6 +28,7 @@ type AutocompleteBaseProps<TValue> = {
   disabled?: boolean;
   onInputChange?: ChangeEventHandler<HTMLInputElement>;
   renderChips?: boolean;
+  getDisplayValue: (val: TValue) => string;
 };
 
 export type IAutocompleteProps<

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -22,7 +22,7 @@ export type ISelectProps<T extends unknown> = {
   onChange: (val: T) => void;
   multiple?: boolean;
   label?: string;
-  renderLabel: (val: T) => string;
+  renderLabel: (val: T) => ReactNode;
   startIcon?: ReactNode;
   endIcon?: ReactNode;
   helperText?: string;


### PR DESCRIPTION
## Description

- By default `getDisplayValue` should be provided to `Autocomplete` component.
- `Autocomplete` and `Select` `renderLabel` function props are now returning a `ReactNode` instead of `string` and overrides `getDisplayValue` for displaying the options.

## Related Issue

Fixes #5