### PR TITLE
fix: add initialFocus prop to dialog

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -19,9 +19,21 @@ import type { IDialogProps } from "./Dialog.types";
 import { Button } from "../Button";
 import { twMerge } from "tailwind-merge";
 
-function Dialog({ open, onClose, title, children, className }: IDialogProps) {
+function Dialog({
+  open,
+  onClose,
+  title,
+  children,
+  className,
+  initialFocus,
+}: IDialogProps) {
   return (
-    <HeadlessDialog className="dialog__container" open={open} onClose={onClose}>
+    <HeadlessDialog
+      initialFocus={initialFocus}
+      className="dialog__container"
+      open={open}
+      onClose={onClose}
+    >
       <div className="dialog__overlay" aria-hidden="true" />
       <div className="dialog__overlay__content">
         <HeadlessDialog.Panel

--- a/src/components/Dialog/Dialog.types.ts
+++ b/src/components/Dialog/Dialog.types.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren, ReactNode } from "react";
+import { MutableRefObject, PropsWithChildren, ReactNode } from "react";
 
 export interface IDialogProps extends PropsWithChildren<{}> {
   open: boolean;
   onClose: () => void;
   title?: ReactNode;
   className?: string;
+  initialFocus?: MutableRefObject<HTMLElement | null>;
 }


### PR DESCRIPTION
## Description

Instead of removing `initialFocus` from close button, the `Dialog` is now extended in order to accept `initialFocus` prop.

## Related Issue

Fixes #2 