### PR TITLE
feat: use renderValue and renderOptions on autocomplete and select

### DIFF
--- a/.changeset/gorgeous-beds-dance.md
+++ b/.changeset/gorgeous-beds-dance.md
@@ -1,0 +1,5 @@
+---
+"@arkejs/ui": patch
+---
+
+feat: use renderLabel and renderOptions on autocomplete

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -1,4 +1,7 @@
+import { redirect } from "next/navigation";
 export default function Home() {
+  // Temporary redirect for WIP Homepage
+  redirect("/docs/install");
   return (
     <div>
       <h1 className="mb-8 text-center text-3xl font-bold">Arke UI</h1>

--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -19,7 +19,11 @@ The `Autocomplete` component is used to create an input field with suggestions o
       type: "string",
     },
     {
-      name: "renderLabel",
+      name: "renderValue*",
+      type: "(val: TValue) => ReactNode",
+    },
+    {
+      name: "renderOption",
       type: "(val: TValue) => ReactNode",
     },
     {

--- a/apps/docs/content/docs/components/select.mdx
+++ b/apps/docs/content/docs/components/select.mdx
@@ -50,8 +50,12 @@ The `Select` component is used to allow the user to select an option from a drop
       type: "(value: T) => void",
     },
     {
-      name: "renderLabel*",
-      type: "(value: T) => ReactNode",
+      name: "renderValue*",
+      type: "(val: TValue) => ReactNode",
+    },
+    {
+      name: "renderOption",
+      type: "(val: TValue) => ReactNode",
     },
     {
       name: "value",

--- a/apps/docs/examples/Autocomplete.tsx
+++ b/apps/docs/examples/Autocomplete.tsx
@@ -29,7 +29,7 @@ function MyAutocomplete() {
         values={filteredValues}
         onInputChange={(e) => setSearch(e.target.value)}
         onChange={(val) => setValue(val)}
-        getDisplayValue={(val) => val?.name}
+        renderLabel={(val) => val?.name}
       />
     </div>
   );

--- a/apps/docs/examples/Autocomplete.tsx
+++ b/apps/docs/examples/Autocomplete.tsx
@@ -29,7 +29,7 @@ function MyAutocomplete() {
         values={filteredValues}
         onInputChange={(e) => setSearch(e.target.value)}
         onChange={(val) => setValue(val)}
-        renderLabel={(val) => val?.name}
+        renderValue={(val) => val?.name}
       />
     </div>
   );

--- a/apps/docs/examples/Select.tsx
+++ b/apps/docs/examples/Select.tsx
@@ -19,7 +19,7 @@ function MySelect() {
         value={value}
         values={departments}
         onChange={(value) => setValue(value)}
-        renderLabel={(value) => value.name}
+        renderValue={(value) => value.name}
       />
     </div>
   );

--- a/apps/storybook/src/stories/Autocomplete.stories.tsx
+++ b/apps/storybook/src/stories/Autocomplete.stories.tsx
@@ -37,7 +37,7 @@ export const Default = (args: Story["args"]) => {
       values={filteredValues}
       onInputChange={(e) => setSearch(e.target.value)}
       onChange={handleChange}
-      renderLabel={(val) => val?.name}
+      renderValue={(val) => val?.name}
       placeholder="Search..."
     />
   );
@@ -65,7 +65,7 @@ export const Nullable = (args: Story["args"]) => {
           setSearch(e.target.value);
         }}
         onChange={handleChange}
-        renderLabel={(val) => val?.name}
+        renderValue={(val) => val?.name}
         placeholder="Search..."
       />
     </>
@@ -93,7 +93,7 @@ export const Clearable = (args: Story["args"]) => {
         setSearch(e.target.value);
       }}
       onChange={handleChange}
-      renderLabel={(val) => val?.name}
+      renderValue={(val) => val?.name}
       placeholder="Search..."
     />
   );

--- a/apps/storybook/src/stories/Autocomplete.stories.tsx
+++ b/apps/storybook/src/stories/Autocomplete.stories.tsx
@@ -37,7 +37,7 @@ export const Default = (args: Story["args"]) => {
       values={filteredValues}
       onInputChange={(e) => setSearch(e.target.value)}
       onChange={handleChange}
-      getDisplayValue={(val) => val?.name}
+      renderLabel={(val) => val?.name}
       placeholder="Search..."
     />
   );
@@ -65,7 +65,7 @@ export const Nullable = (args: Story["args"]) => {
           setSearch(e.target.value);
         }}
         onChange={handleChange}
-        getDisplayValue={(val) => val?.name}
+        renderLabel={(val) => val?.name}
         placeholder="Search..."
       />
     </>
@@ -93,7 +93,7 @@ export const Clearable = (args: Story["args"]) => {
         setSearch(e.target.value);
       }}
       onChange={handleChange}
-      getDisplayValue={(val) => val?.name}
+      renderLabel={(val) => val?.name}
       placeholder="Search..."
     />
   );

--- a/apps/storybook/src/stories/Select.stories.tsx
+++ b/apps/storybook/src/stories/Select.stories.tsx
@@ -30,7 +30,7 @@ export const Default = (args: Story["args"]) => {
       value={value}
       onChange={handleChange}
       values={values}
-      renderLabel={(item) => item?.name}
+      renderValue={(val) => val?.name}
     />
   );
 };
@@ -48,7 +48,7 @@ export const Multiple = (args: Story["args"]) => {
       onChange={handleChange}
       values={values}
       multiple
-      renderLabel={(item) => item?.name}
+      renderValue={(val) => val?.name}
     />
   );
 };

--- a/packages/ui/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.test.tsx
@@ -30,7 +30,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.id}
+        renderValue={(val) => val.id}
       />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -41,7 +41,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.id}
+        renderValue={(val) => val.id}
       />
     );
     expect(getByTestId("arke-autocomplete")).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.id}
+        renderValue={(val) => val.id}
         onInputChange={onInputChange}
       />
     );
@@ -67,7 +67,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
       />
     );
     await userEvent.type(getByTestId("arke-autocomplete"), "Test");
@@ -81,7 +81,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={onChange}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
       />
     );
     await userEvent.type(getByTestId("arke-autocomplete"), "Test");
@@ -90,12 +90,12 @@ describe("Autocomplete", () => {
     expect(onChange).toHaveBeenCalled();
   });
 
-  test("should render correct label when renderLabel is provided", async () => {
+  test("should render correct label when renderValue is provided", async () => {
     const { getByTestId, getByText } = render(
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
         renderOption={(val) => val.id}
       />
     );
@@ -108,7 +108,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
         value={mockValues[0]}
       />
     );
@@ -120,7 +120,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
         multiple
         value={mockValues}
       />
@@ -135,7 +135,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={onChange}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
         multiple
         value={[mockValues[0], mockValues[1]]}
       />
@@ -151,7 +151,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
         startAdornment={"start adornment"}
         endAdornment={"end adornment"}
       />

--- a/packages/ui/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.test.tsx
@@ -30,7 +30,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        getDisplayValue={(val) => val.id}
+        renderLabel={(val) => val.id}
       />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -41,7 +41,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        getDisplayValue={(val) => val.id}
+        renderLabel={(val) => val.id}
       />
     );
     expect(getByTestId("arke-autocomplete")).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        getDisplayValue={(val) => val.id}
+        renderLabel={(val) => val.id}
         onInputChange={onInputChange}
       />
     );
@@ -67,7 +67,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        getDisplayValue={(val) => val.name}
+        renderLabel={(val) => val.name}
       />
     );
     await userEvent.type(getByTestId("arke-autocomplete"), "Test");
@@ -81,7 +81,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={onChange}
         values={mockValues}
-        getDisplayValue={(val) => val.name}
+        renderLabel={(val) => val.name}
       />
     );
     await userEvent.type(getByTestId("arke-autocomplete"), "Test");
@@ -95,8 +95,8 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        getDisplayValue={(val) => val.name}
-        renderLabel={(val) => val.id}
+        renderLabel={(val) => val.name}
+        renderOption={(val) => val.id}
       />
     );
     await userEvent.type(getByTestId("arke-autocomplete"), "Test");
@@ -108,7 +108,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        getDisplayValue={(val) => val.name}
+        renderLabel={(val) => val.name}
         value={mockValues[0]}
       />
     );
@@ -120,7 +120,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        getDisplayValue={(val) => val.name}
+        renderLabel={(val) => val.name}
         multiple
         value={mockValues}
       />
@@ -135,7 +135,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={onChange}
         values={mockValues}
-        getDisplayValue={(val) => val.name}
+        renderLabel={(val) => val.name}
         multiple
         value={[mockValues[0], mockValues[1]]}
       />
@@ -151,7 +151,7 @@ describe("Autocomplete", () => {
       <Autocomplete
         onChange={() => null}
         values={mockValues}
-        getDisplayValue={(val) => val.name}
+        renderLabel={(val) => val.name}
         startAdornment={"start adornment"}
         endAdornment={"end adornment"}
       />

--- a/packages/ui/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.tsx
@@ -69,7 +69,7 @@ function Autocomplete<TValue>({
   helperText,
   onChange,
   onInputChange,
-  renderLabel,
+  renderValue,
   renderChips = true,
   nullable,
   clearable,
@@ -83,19 +83,19 @@ function Autocomplete<TValue>({
   const [inputValue, setInputValue] = useState<string>("");
   type TActualValue = true extends typeof multiple ? TValue[] : TValue;
 
-  const onRenderLabel = (value: TValue) =>
+  const onrenderValue = (value: TValue) =>
     (value &&
       (Array.isArray(value)
-        ? (value as TValue[]).map((val) => renderLabel(val)).join(", ")
-        : renderLabel(value))) ??
+        ? (value as TValue[]).map((val) => renderValue(val)).join(", ")
+        : renderValue(value))) ??
     "";
 
   function updateInputValue() {
     if (multiple) {
       setInputValue("");
     } else {
-      if (inputValue !== onRenderLabel(value as TValue))
-        setInputValue(onRenderLabel(value as TValue));
+      if (inputValue !== onrenderValue(value as TValue))
+        setInputValue(onrenderValue(value as TValue));
     }
   }
 
@@ -140,7 +140,7 @@ function Autocomplete<TValue>({
             <Combobox.Input
               as={Fragment}
               onChange={(e) => onInputChange?.(e)}
-              displayValue={onRenderLabel}
+              displayValue={onrenderValue}
             >
               <>
                 <div
@@ -165,7 +165,7 @@ function Autocomplete<TValue>({
                         className="autocomplete__chip"
                         onDelete={() => handleOnDelete(index)}
                       >
-                        {onRenderLabel(item)}
+                        {onrenderValue(item)}
                       </Chip>
                     ))}
                   <input
@@ -229,7 +229,7 @@ function Autocomplete<TValue>({
                       (selected || active) && "autocomplete__option--active"
                     )}
                   >
-                    {renderOption ? renderOption(val) : renderLabel(val)}
+                    {renderOption ? renderOption(val) : renderValue(val)}
                   </li>
                 )}
               </Combobox.Option>

--- a/packages/ui/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.tsx
@@ -63,13 +63,13 @@ function Autocomplete<TValue>({
   label,
   placeholder,
   multiple,
-  renderLabel,
+  renderOption,
   startAdornment,
   endAdornment,
   helperText,
   onChange,
   onInputChange,
-  getDisplayValue,
+  renderLabel,
   renderChips = true,
   nullable,
   clearable,
@@ -83,19 +83,19 @@ function Autocomplete<TValue>({
   const [inputValue, setInputValue] = useState<string>("");
   type TActualValue = true extends typeof multiple ? TValue[] : TValue;
 
-  const onGetDisplayValue = (value: TValue) =>
+  const onRenderLabel = (value: TValue) =>
     (value &&
       (Array.isArray(value)
-        ? (value as TValue[]).map((val) => getDisplayValue(val)).join(", ")
-        : getDisplayValue(value))) ??
+        ? (value as TValue[]).map((val) => renderLabel(val)).join(", ")
+        : renderLabel(value))) ??
     "";
 
   function updateInputValue() {
     if (multiple) {
       setInputValue("");
     } else {
-      if (inputValue !== onGetDisplayValue(value as TValue))
-        setInputValue(onGetDisplayValue(value as TValue));
+      if (inputValue !== onRenderLabel(value as TValue))
+        setInputValue(onRenderLabel(value as TValue));
     }
   }
 
@@ -140,7 +140,7 @@ function Autocomplete<TValue>({
             <Combobox.Input
               as={Fragment}
               onChange={(e) => onInputChange?.(e)}
-              displayValue={onGetDisplayValue}
+              displayValue={onRenderLabel}
             >
               <>
                 <div
@@ -165,7 +165,7 @@ function Autocomplete<TValue>({
                         className="autocomplete__chip"
                         onDelete={() => handleOnDelete(index)}
                       >
-                        {onGetDisplayValue(item)}
+                        {onRenderLabel(item)}
                       </Chip>
                     ))}
                   <input
@@ -229,7 +229,7 @@ function Autocomplete<TValue>({
                       (selected || active) && "autocomplete__option--active"
                     )}
                   >
-                    {renderLabel ? renderLabel(val) : getDisplayValue(val)}
+                    {renderOption ? renderOption(val) : renderLabel(val)}
                   </li>
                 )}
               </Combobox.Option>

--- a/packages/ui/src/components/Autocomplete/Autocomplete.types.ts
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.types.ts
@@ -19,7 +19,8 @@ import { ChangeEventHandler, ReactNode } from "react";
 type AutocompleteBaseProps<TValue> = {
   values?: TValue[];
   label?: string;
-  renderLabel?: (val: TValue) => ReactNode;
+  renderLabel: (val: TValue) => string | undefined;
+  renderOption?: (val: TValue) => ReactNode;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
   placeholder?: string;
@@ -28,7 +29,6 @@ type AutocompleteBaseProps<TValue> = {
   disabled?: boolean;
   onInputChange?: ChangeEventHandler<HTMLInputElement>;
   renderChips?: boolean;
-  getDisplayValue: (val: TValue) => string | undefined;
   className?: string;
   clearIcon?: ReactNode;
 };

--- a/packages/ui/src/components/Autocomplete/Autocomplete.types.ts
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.types.ts
@@ -19,7 +19,7 @@ import { ChangeEventHandler, ReactNode } from "react";
 type AutocompleteBaseProps<TValue> = {
   values?: TValue[];
   label?: string;
-  renderLabel: (val: TValue) => string | undefined;
+  renderValue: (val: TValue) => string | undefined;
   renderOption?: (val: TValue) => ReactNode;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -30,7 +30,7 @@ describe("Select", () => {
       <Select
         values={mockValues}
         onChange={() => null}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
       />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -41,7 +41,7 @@ describe("Select", () => {
       <Select
         values={mockValues}
         onChange={() => null}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
       />
     );
     expect(getByTestId("arke-select")).toBeInTheDocument();
@@ -52,7 +52,7 @@ describe("Select", () => {
       <Select
         values={mockValues}
         onChange={() => null}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
       />
     );
     await userEvent.click(getByTestId("arke-select"));
@@ -67,7 +67,7 @@ describe("Select", () => {
       <Select
         values={mockValues}
         onChange={onChange}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
       />
     );
     await userEvent.click(getByTestId("arke-select"));
@@ -80,7 +80,7 @@ describe("Select", () => {
       <Select
         values={mockValues}
         onChange={() => null}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
         value={mockValues[0]}
       />
     );
@@ -92,7 +92,7 @@ describe("Select", () => {
       <Select
         values={mockValues}
         onChange={() => null}
-        renderLabel={(val) => val.name}
+        renderValue={(val) => val.name}
         value={mockValues[0]}
         startAdornment={"start adornment"}
         endAdornment={"end adornment"}

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -44,7 +44,7 @@ function Select<T>({
   multiple = false,
   onChange,
   label,
-  renderLabel,
+  renderValue,
   renderOption,
   startAdornment,
   endAdornment,
@@ -64,7 +64,7 @@ function Select<T>({
       >
         {label && <Listbox.Label className="label">{label}</Listbox.Label>}
         <div className={twMerge("select__container", className)}>
-          <div className="w-full flex items-center">
+          <div className="flex w-full items-center">
             {startAdornment && (
               <Listbox.Button className="select__startAdornment">
                 {startAdornment}
@@ -79,9 +79,9 @@ function Select<T>({
             >
               {value ? (
                 Array.isArray(value) ? (
-                  value.map((val) => renderLabel(val)).join(", ")
+                  value.map((val) => renderValue(val)).join(", ")
                 ) : (
-                  renderLabel(value)
+                  renderValue(value)
                 )
               ) : (
                 <span className="select__placeholder">
@@ -111,7 +111,7 @@ function Select<T>({
                       (selected || active) && "select__option--active"
                     )}
                   >
-                    {renderOption ? renderOption(val) : renderLabel(val)}
+                    {renderOption ? renderOption(val) : renderValue(val)}
                   </li>
                 )}
               </Listbox.Option>

--- a/packages/ui/src/components/Select/Select.types.ts
+++ b/packages/ui/src/components/Select/Select.types.ts
@@ -22,7 +22,7 @@ export type ISelectProps<T extends unknown> = {
   onChange: (val: T) => void;
   multiple?: boolean;
   label?: string;
-  renderLabel: (val: T) => ReactNode;
+  renderValue: (val: T) => ReactNode;
   renderOption?: (val: T) => ReactNode;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;

--- a/packages/ui/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/ui/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Select should match snapshot 1`] = `
       class="select__container"
     >
       <div
-        class="w-full flex items-center"
+        class="flex w-full items-center"
       >
         <button
           aria-expanded="false"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -46,7 +46,7 @@ importers:
         version: 2.8.8
       turbo:
         specifier: latest
-        version: 1.10.7
+        version: 1.8.8
 
   apps/docs:
     dependencies:
@@ -16290,65 +16290,65 @@ packages:
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
     dev: true
 
-  /turbo-darwin-64@1.10.7:
-    resolution: {integrity: sha512-N2MNuhwrl6g7vGuz4y3fFG2aR1oCs0UZ5HKl8KSTn/VC2y2YIuLGedQ3OVbo0TfEvygAlF3QGAAKKtOCmGPNKA==}
+  /turbo-darwin-64@1.8.8:
+    resolution: {integrity: sha512-18cSeIm7aeEvIxGyq7PVoFyEnPpWDM/0CpZvXKHpQ6qMTkfNt517qVqUTAwsIYqNS8xazcKAqkNbvU1V49n65Q==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-darwin-arm64@1.10.7:
-    resolution: {integrity: sha512-WbJkvjU+6qkngp7K4EsswOriO3xrNQag7YEGRtfLoDdMTk4O4QTeU6sfg2dKfDsBpTidTvEDwgIYJhYVGzrz9Q==}
+  /turbo-darwin-arm64@1.8.8:
+    resolution: {integrity: sha512-ruGRI9nHxojIGLQv1TPgN7ud4HO4V8mFBwSgO6oDoZTNuk5ybWybItGR+yu6fni5vJoyMHXOYA2srnxvOc7hjQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-linux-64@1.10.7:
-    resolution: {integrity: sha512-x1CF2CDP1pDz/J8/B2T0hnmmOQI2+y11JGIzNP0KtwxDM7rmeg3DDTtDM/9PwGqfPotN9iVGgMiMvBuMFbsLhg==}
+  /turbo-linux-64@1.8.8:
+    resolution: {integrity: sha512-N/GkHTHeIQogXB1/6ZWfxHx+ubYeb8Jlq3b/3jnU4zLucpZzTQ8XkXIAfJG/TL3Q7ON7xQ8yGOyGLhHL7MpFRg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-linux-arm64@1.10.7:
-    resolution: {integrity: sha512-JtnBmaBSYbs7peJPkXzXxsRGSGBmBEIb6/kC8RRmyvPAMyqF8wIex0pttsI+9plghREiGPtRWv/lfQEPRlXnNQ==}
+  /turbo-linux-arm64@1.8.8:
+    resolution: {integrity: sha512-hKqLbBHgUkYf2Ww8uBL9UYdBFQ5677a7QXdsFhONXoACbDUPvpK4BKlz3NN7G4NZ+g9dGju+OJJjQP0VXRHb5w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-windows-64@1.10.7:
-    resolution: {integrity: sha512-7A/4CByoHdolWS8dg3DPm99owfu1aY/W0V0+KxFd0o2JQMTQtoBgIMSvZesXaWM57z3OLsietFivDLQPuzE75w==}
+  /turbo-windows-64@1.8.8:
+    resolution: {integrity: sha512-2ndjDJyzkNslXxLt+PQuU21AHJWc8f6MnLypXy3KsN4EyX/uKKGZS0QJWz27PeHg0JS75PVvhfFV+L9t9i+Yyg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-windows-arm64@1.10.7:
-    resolution: {integrity: sha512-D36K/3b6+hqm9IBAymnuVgyePktwQ+F0lSXr2B9JfAdFPBktSqGmp50JNC7pahxhnuCLj0Vdpe9RqfnJw5zATA==}
+  /turbo-windows-arm64@1.8.8:
+    resolution: {integrity: sha512-xCA3oxgmW9OMqpI34AAmKfOVsfDljhD5YBwgs0ZDsn5h3kCHhC4x9W5dDk1oyQ4F5EXSH3xVym5/xl1J6WRpUg==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo@1.10.7:
-    resolution: {integrity: sha512-xm0MPM28TWx1e6TNC3wokfE5eaDqlfi0G24kmeHupDUZt5Wd0OzHFENEHMPqEaNKJ0I+AMObL6nbSZonZBV2HA==}
+  /turbo@1.8.8:
+    resolution: {integrity: sha512-qYJ5NjoTX+591/x09KgsDOPVDUJfU9GoS+6jszQQlLp1AHrf1wRFA3Yps8U+/HTG03q0M4qouOfOLtRQP4QypA==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.10.7
-      turbo-darwin-arm64: 1.10.7
-      turbo-linux-64: 1.10.7
-      turbo-linux-arm64: 1.10.7
-      turbo-windows-64: 1.10.7
-      turbo-windows-arm64: 1.10.7
+      turbo-darwin-64: 1.8.8
+      turbo-darwin-arm64: 1.8.8
+      turbo-linux-64: 1.8.8
+      turbo-linux-arm64: 1.8.8
+      turbo-windows-64: 1.8.8
+      turbo-windows-arm64: 1.8.8
     dev: false
 
   /typanion@3.12.1:


### PR DESCRIPTION
## Description

Unify naming between components - use renderValue for value and renderOptions for options

```
<Select
     {...args}
     label="Select an item"
     value={value}
     onChange={handleChange}
     values={values}
     renderValue={(val) => val?.name}
     renderValue={(val) => val?.label}
 />
```

## Test

- [x] I have added tests that prove my fix is effective or that my feature works
