### PR TITLE
feat: Dialog disableBackdropClose and close reason

### DIFF
--- a/.changeset/sixty-meals-greet.md
+++ b/.changeset/sixty-meals-greet.md
@@ -1,0 +1,5 @@
+---
+"@arkejs/ui": minor
+---
+
+feat: Dialog backdropClose and close reason

--- a/.changeset/sixty-meals-greet.md
+++ b/.changeset/sixty-meals-greet.md
@@ -2,4 +2,4 @@
 "@arkejs/ui": minor
 ---
 
-feat: Dialog backdropClose and close reason
+feat: Dialog disableBackdropClose and close reason

--- a/apps/docs/content/docs/components/dialog.mdx
+++ b/apps/docs/content/docs/components/dialog.mdx
@@ -16,7 +16,7 @@ The `Dialog` component is used to display a modal dialog box that requires user 
     },
     {
       name: "onClose*",
-      type: "() => void",
+      type: "(reason: TDialogCloseReason) => void",
     },
     {
       name: "open*",
@@ -29,6 +29,10 @@ The `Dialog` component is used to display a modal dialog box that requires user 
     {
       name: "children",
       type: "",
+    },
+    {
+      name: "backdropClose",
+      type: "boolean",
     },
   ]}
 />

--- a/apps/docs/content/docs/components/dialog.mdx
+++ b/apps/docs/content/docs/components/dialog.mdx
@@ -33,6 +33,7 @@ The `Dialog` component is used to display a modal dialog box that requires user 
     {
       name: "disableBackdropClose",
       type: "boolean",
+      defaultValue: "false",
     },
   ]}
 />

--- a/apps/docs/content/docs/components/dialog.mdx
+++ b/apps/docs/content/docs/components/dialog.mdx
@@ -31,7 +31,7 @@ The `Dialog` component is used to display a modal dialog box that requires user 
       type: "",
     },
     {
-      name: "backdropClose",
+      name: "disableBackdropClose",
       type: "boolean",
     },
   ]}

--- a/apps/docs/examples/Dialog.tsx
+++ b/apps/docs/examples/Dialog.tsx
@@ -8,7 +8,12 @@ function MyDialog() {
       <Button color="primary" onClick={() => setOpen(true)}>
         Open Dialog
       </Button>
-      <Dialog title="Dialog" open={open} onClose={() => setOpen(false)}>
+      <Dialog
+        title="Dialog"
+        open={open}
+        onClose={() => setOpen(false)}
+        backdropClose
+      >
         Hey!
       </Dialog>
     </>

--- a/apps/docs/examples/Dialog.tsx
+++ b/apps/docs/examples/Dialog.tsx
@@ -12,7 +12,7 @@ function MyDialog() {
         title="Dialog"
         open={open}
         onClose={() => setOpen(false)}
-        backdropClose
+        disableBackdropClose
       >
         Hey!
       </Dialog>

--- a/packages/ui/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.test.tsx
@@ -60,15 +60,6 @@ describe("Dialog", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("should call onClose when backdrop is clicked with backdropClick reason", async () => {
-    const onClose = jest.fn();
-    const { getByTestId } = render(
-      <Dialog open={true} onClose={onClose} disableBackdropClose={false} />
-    );
-    await userEvent.click(getByTestId("arke-dialog-backdrop"));
-    expect(onClose).toHaveBeenCalledWith("backdropClick");
-  });
-
   it("should render title", () => {
     const { getByText } = render(
       <Dialog open={true} onClose={() => null} title="Title" />

--- a/packages/ui/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.test.tsx
@@ -51,19 +51,19 @@ describe("Dialog", () => {
     expect(onClose).toHaveBeenCalledWith("closeButton");
   });
 
-  it("should not call onClose when backdropClose is false", async () => {
+  it("should not call onClose when disableBackdropClose is true", async () => {
     const onClose = jest.fn();
     const { getByTestId } = render(
-      <Dialog open={true} onClose={onClose} backdropClose={false} />
+      <Dialog open={true} onClose={onClose} disableBackdropClose />
     );
     await userEvent.click(getByTestId("arke-dialog-backdrop"));
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("should call onClose when backdrop button is clicked with backdropClick reason", async () => {
+  it("should call onClose when backdrop is clicked with backdropClick reason", async () => {
     const onClose = jest.fn();
     const { getByTestId } = render(
-      <Dialog open={true} onClose={onClose} backdropClose />
+      <Dialog open={true} onClose={onClose} disableBackdropClose={false} />
     );
     await userEvent.click(getByTestId("arke-dialog-backdrop"));
     expect(onClose).toHaveBeenCalledWith("backdropClick");

--- a/packages/ui/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.test.tsx
@@ -44,11 +44,29 @@ describe("Dialog", () => {
     expect(queryAllByTestId("arke-dialog")).toHaveLength(0);
   });
 
-  it("should call onClose when close button is clicked", async () => {
+  it("should call onClose when close button is clicked with closeButton reason", async () => {
     const onClose = jest.fn();
     const { getByTestId } = render(<Dialog open={true} onClose={onClose} />);
     await userEvent.click(getByTestId("arke-dialog-close"));
-    expect(onClose).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledWith("closeButton");
+  });
+
+  it("should not call onClose when backdropClose is false", async () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <Dialog open={true} onClose={onClose} backdropClose={false} />
+    );
+    await userEvent.click(getByTestId("arke-dialog-backdrop"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("should call onClose when backdrop button is clicked with backdropClick reason", async () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <Dialog open={true} onClose={onClose} backdropClose />
+    );
+    await userEvent.click(getByTestId("arke-dialog-backdrop"));
+    expect(onClose).toHaveBeenCalledWith("backdropClick");
   });
 
   it("should render title", () => {

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -45,12 +45,9 @@ function Dialog({
       className="dialog__container"
       open={open}
       onClose={() => handleClose("backdropClick")}
+      data-testid="arke-dialog-backdrop"
     >
-      <div
-        className="dialog__overlay"
-        aria-hidden="true"
-        data-testid="arke-dialog-backdrop"
-      />
+      <div className="dialog__overlay" aria-hidden="true" />
       <div className="dialog__overlay__content">
         <HeadlessDialog.Panel
           data-testid="arke-dialog"

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -20,6 +20,7 @@ import { Dialog as HeadlessDialog } from "@headlessui/react";
 import type { IDialogProps } from "./Dialog.types";
 import { Button } from "../Button";
 import { twMerge } from "tailwind-merge";
+import { TDialogCloseReason } from "./Dialog.types";
 
 function Dialog({
   open,
@@ -28,15 +29,28 @@ function Dialog({
   children,
   className,
   initialFocus,
+  backdropClose = false,
 }: IDialogProps) {
+  const handleClose = (reason: TDialogCloseReason) => {
+    if (reason == "backdropClick" && backdropClose) {
+      onClose(reason);
+    } else if (reason == "closeButton") {
+      onClose(reason);
+    }
+  };
+
   return (
     <HeadlessDialog
       initialFocus={initialFocus}
       className="dialog__container"
       open={open}
-      onClose={onClose}
+      onClose={() => handleClose("backdropClick")}
     >
-      <div className="dialog__overlay" aria-hidden="true" />
+      <div
+        className="dialog__overlay"
+        aria-hidden="true"
+        data-testid="arke-dialog-backdrop"
+      />
       <div className="dialog__overlay__content">
         <HeadlessDialog.Panel
           data-testid="arke-dialog"
@@ -44,7 +58,10 @@ function Dialog({
         >
           <div className="dialog__head">
             {title && <p className="dialog__title">{title}</p>}
-            <Button onClick={onClose} className="dialog__close__button">
+            <Button
+              onClick={() => handleClose("closeButton")}
+              className="dialog__close__button"
+            >
               <svg
                 data-testid="arke-dialog-close"
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -29,10 +29,10 @@ function Dialog({
   children,
   className,
   initialFocus,
-  backdropClose = false,
+  disableBackdropClose = true,
 }: IDialogProps) {
   const handleClose = (reason: TDialogCloseReason) => {
-    if (reason == "backdropClick" && backdropClose) {
+    if (reason == "backdropClick" && !disableBackdropClose) {
       onClose(reason);
     } else if (reason == "closeButton") {
       onClose(reason);

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -29,7 +29,7 @@ function Dialog({
   children,
   className,
   initialFocus,
-  disableBackdropClose = true,
+  disableBackdropClose,
 }: IDialogProps) {
   const handleClose = (reason: TDialogCloseReason) => {
     if (reason == "backdropClick" && !disableBackdropClose) {

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -29,7 +29,7 @@ function Dialog({
   children,
   className,
   initialFocus,
-  disableBackdropClose,
+  disableBackdropClose = false,
 }: IDialogProps) {
   const handleClose = (reason: TDialogCloseReason) => {
     if (reason == "backdropClick" && !disableBackdropClose) {

--- a/packages/ui/src/components/Dialog/Dialog.types.ts
+++ b/packages/ui/src/components/Dialog/Dialog.types.ts
@@ -24,5 +24,5 @@ export interface IDialogProps extends PropsWithChildren<{}> {
   title?: ReactNode;
   className?: string;
   initialFocus?: MutableRefObject<HTMLElement | null>;
-  backdropClose?: boolean;
+  disableBackdropClose?: boolean;
 }

--- a/packages/ui/src/components/Dialog/Dialog.types.ts
+++ b/packages/ui/src/components/Dialog/Dialog.types.ts
@@ -16,10 +16,13 @@
 
 import { MutableRefObject, PropsWithChildren, ReactNode } from "react";
 
+export type TDialogCloseReason = "backdropClick" | "closeButton";
+
 export interface IDialogProps extends PropsWithChildren<{}> {
   open: boolean;
-  onClose: () => void;
+  onClose: (reason: TDialogCloseReason) => void;
   title?: ReactNode;
   className?: string;
   initialFocus?: MutableRefObject<HTMLElement | null>;
+  backdropClose?: boolean;
 }


### PR DESCRIPTION
## Description

Add `disableBackdropClose` props (default = true) to define if Dialog can close on backdrop click, now `onClose` function receive a reason to define who invoke it

```
<Dialog
  ...
  onClose={() => setOpen(false)}
  disableBackdropClose={false}
>
  Hey!
</Dialog>
```

Reason
```
export type TDialogCloseReason = "backdropClick" | "closeButton";
```

## Issues

#29 

## Test

- [x] I have added tests that prove my fix is effective or that my feature works
