### PR TITLE
chore: label types

### DIFF
--- a/.changeset/hungry-news-tease.md
+++ b/.changeset/hungry-news-tease.md
@@ -1,0 +1,5 @@
+---
+"@arkejs/ui": patch
+---
+
+chore: extend label type with ReactNode

--- a/packages/ui/src/components/Autocomplete/Autocomplete.types.ts
+++ b/packages/ui/src/components/Autocomplete/Autocomplete.types.ts
@@ -18,7 +18,7 @@ import { ChangeEventHandler, ReactNode } from "react";
 
 type AutocompleteBaseProps<TValue> = {
   values?: TValue[];
-  label?: string;
+  label?: string | ReactNode;
   renderValue: (val: TValue) => string | undefined;
   renderOption?: (val: TValue) => ReactNode;
   startAdornment?: ReactNode;

--- a/packages/ui/src/components/Badge/Badge.types.ts
+++ b/packages/ui/src/components/Badge/Badge.types.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, ReactNode } from "react";
 
 export interface IBadgeProps extends PropsWithChildren<{}> {
   className?: string;
   color?: "primary" | "secondary";
-  label?: string;
+  label?: string | ReactNode;
 }

--- a/packages/ui/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/ui/src/components/Checkbox/Checkbox.types.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { ChangeEventHandler } from "react";
+import { ChangeEventHandler, ReactNode } from "react";
 
 export interface ICheckboxProps {
   name?: string;
   checked: boolean;
   onChange: ChangeEventHandler<HTMLInputElement>;
   disabled?: boolean;
-  label?: string;
+  label?: string | ReactNode;
   helperText?: string;
   hasError?: boolean;
   labelPlacement?: "top" | "bottom" | "left" | "right";

--- a/packages/ui/src/components/Input/Input.types.ts
+++ b/packages/ui/src/components/Input/Input.types.ts
@@ -20,7 +20,7 @@ export type IInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   fullWidth?: boolean;
   helperText?: string;
   hasError?: boolean;
-  label?: string;
+  label?: string | ReactNode;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
   prefixAdornment?: ReactNode;

--- a/packages/ui/src/components/Json/Json.types.ts
+++ b/packages/ui/src/components/Json/Json.types.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ReactNode } from "react";
 
 interface IJsonProps {
   height?: string | number;
   width?: string | number;
   value: string;
   onChange?: (value: string) => void;
-  label?: string;
+  label?: string | ReactNode;
   readOnly?: boolean;
   className?: string;
 }

--- a/packages/ui/src/components/Radio/Radio.types.ts
+++ b/packages/ui/src/components/Radio/Radio.types.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangeEventHandler } from "react";
+import { ChangeEventHandler, ReactNode } from "react";
 
 export interface IRadioProps {
   name?: string;
-  label?: string;
+  label?: string | ReactNode;
   labelPlacement?: "top" | "bottom" | "left" | "right";
   color?: "primary" | "secondary";
   checked?: boolean;

--- a/packages/ui/src/components/Select/Select.types.ts
+++ b/packages/ui/src/components/Select/Select.types.ts
@@ -21,7 +21,7 @@ export type ISelectProps<T extends unknown> = {
   values?: T[];
   onChange: (val: T) => void;
   multiple?: boolean;
-  label?: string;
+  label?: string | ReactNode;
   renderValue: (val: T) => ReactNode;
   renderOption?: (val: T) => ReactNode;
   startAdornment?: ReactNode;

--- a/packages/ui/src/components/Switch/Switch.types.ts
+++ b/packages/ui/src/components/Switch/Switch.types.ts
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ReactNode } from "react";
 
 export interface ISwitchProps {
   checked?: boolean;
   onChange?: () => void;
   color?: "primary" | "secondary";
-  label?: string;
+  label?: string | ReactNode;
   labelPosition?: "top" | "right" | "bottom" | "left";
   size?: "sm" | "md";
   disabled?: boolean;

--- a/packages/ui/src/components/TextArea/TextArea.types.ts
+++ b/packages/ui/src/components/TextArea/TextArea.types.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, { ReactNode } from "react";
 
 export type ITextAreaProps =
   React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
-    label?: string;
+    label?: string | ReactNode;
   };


### PR DESCRIPTION
## Description

Add `ReactNode` on label types to support custom label:

```
 <Input
   type="text"
   label={<div>Email *</div>}
   name="username"
/>

 <Input
   type="text"
   label={<Label required>Email</Label>}
   name="username"
/>
```
