### PR TITLE
fix: useOnClickOutside hook if handler doesn't exist

### DIFF
--- a/packages/ui/src/hooks/useClickOutside.ts
+++ b/packages/ui/src/hooks/useClickOutside.ts
@@ -22,7 +22,7 @@ function useOnClickOutside(ref: any, handler: any) {
       if (!ref.current || ref.current.contains(event?.target)) {
         return;
       }
-      handler(event);
+      handler?.(event);
     };
     document.addEventListener("mousedown", listener);
     document.addEventListener("touchstart", listener);


### PR DESCRIPTION
## Description

useOnClickOutside hook if handler doesn't exist

## Test

- [x] I have added tests that prove my fix is effective or that my feature works
